### PR TITLE
Fix update-gemfile.sh when using podman-compose

### DIFF
--- a/update-gemfile.sh
+++ b/update-gemfile.sh
@@ -1,10 +1,12 @@
 #!/bin/bash -e
 
-COMPOSE=podman-compose
-if ! which "$COMPOSE" 2>&1 1>/dev/null
+if which "podman-compose" 2>&1 1>/dev/null
 then
+	COMPOSE="podman-compose"
+	COMPOSE_ARGS_FOR_RUN="--in-pod False"
+else
 	COMPOSE="docker compose"
 fi
 
 $COMPOSE build
-$COMPOSE run -u "$UID:$GID" awestruct-build-env bundle update "${@}"
+$COMPOSE $COMPOSE_ARGS_FOR_RUN run -u "$UID:$GID" awestruct-build-env bundle update "${@}"


### PR DESCRIPTION
Don't ask me why it's necessary now while it wasn't before, but now we get an error because pods are apparently incompatible with `userns_mode: "keep-id"` in the docker compose file.