### PR TITLE
Remove unnecessary sassc dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'bundler', '2.4.10'
 # Main site dependencies
 gem 'awestruct', '0.6.7'
 gem 'sass'
-gem 'sassc'
 gem 'json'
 gem 'haml', '< 6.0'    # Haml 6 would require udpating our filter registration code
 gem 'uglifier'         # Ruby wrapper for UglifyJS JavaScript compressor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,8 +131,6 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (2.4.0)
-      ffi (~> 1.9)
     shellany (0.0.1)
     temple (0.10.3)
     thor (1.3.1)
@@ -166,7 +164,6 @@ DEPENDENCIES
   redcarpet
   rspec
   sass
-  sassc
   tracer
   uglifier
   webrick


### PR DESCRIPTION
It's never been used for hibernate.org and in.relation.to, and is no longer used for beanvalidation.org.